### PR TITLE
skip goreleaser-docker on retry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,14 +123,16 @@ jobs:
         id: check-ecr-images
         run: |
           REPO_NAME="${{ github.event.repository.name }}"
-          TAG="${{ .Version }}"
-
+          # Strip "v" prefix from tag to match GoReleaser version format
+          TAG="${{ inputs.tag }}"
+          VERSION="${TAG#v}"
+          
           # Check if the arm64 image already exists
-          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag="${TAG}-arm64" --region us-west-2 >/dev/null 2>&1; then
-            echo "ECR image ${REPO_NAME}:${TAG}-arm64 already exists"
+          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag="${VERSION}-arm64" --region us-west-2 >/dev/null 2>&1; then
+            echo "ECR image ${REPO_NAME}:${VERSION}-arm64 already exists"
             echo "images_exist=true" >> $GITHUB_OUTPUT
           else
-            echo "ECR image ${REPO_NAME}:${TAG}-arm64 does not exist"
+            echo "ECR image ${REPO_NAME}:${VERSION}-arm64 does not exist"
             echo "images_exist=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,10 +128,10 @@ jobs:
           VERSION="${TAG#v}"
           
           echo "Checking if ECR image ${REPO_NAME}:${VERSION}-arm64 exists"
-          aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids ${VERSION}-arm64 --region us-west-2
+          aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag=${VERSION}-arm64 --region us-west-2
 
           # Check if the arm64 image already exists
-          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids ${VERSION}-arm64 --region us-west-2 >/dev/null 2>&1; then
+          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag=${VERSION}-arm64 --region us-west-2 >/dev/null 2>&1; then
             echo "ECR image ${REPO_NAME}:${VERSION}-arm64 already exists"
             echo "images_exist=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,23 @@ jobs:
           echo "_workflows/.goreleaser.docker.yaml:"
           cat _workflows/.goreleaser.docker.yaml
 
+      - name: Check if ECR images already exist
+        id: check-ecr-images
+        run: |
+          REPO_NAME="${{ github.event.repository.name }}"
+          TAG="${{ inputs.tag }}"
+
+          # Check if the arm64 image already exists
+          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag="${TAG}-arm64" --region us-west-2 >/dev/null 2>&1; then
+            echo "ECR image ${REPO_NAME}:${TAG}-arm64 already exists"
+            echo "images_exist=true" >> $GITHUB_OUTPUT
+          else
+            echo "ECR image ${REPO_NAME}:${TAG}-arm64 does not exist"
+            echo "images_exist=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Docker Login
+        if: steps.check-ecr-images.outputs.images_exist != 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -127,9 +143,11 @@ jobs:
           password: ${{ secrets.RELENG_GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
+        if: steps.check-ecr-images.outputs.images_exist != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Run GoReleaser
+        if: steps.check-ecr-images.outputs.images_exist != 'true'
         uses: goreleaser/goreleaser-action@v6
         with:
           workdir: _caller
@@ -137,6 +155,11 @@ jobs:
           args: release --clean --config ../_workflows/.goreleaser.docker.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}
+
+      - name: Skip GoReleaser - images already exist
+        if: steps.check-ecr-images.outputs.images_exist == 'true'
+        run: |
+          echo "Skipping GoReleaser because ECR images already exist for tag ${{ inputs.tag }}"
 
   record-release:
     needs: [goreleaser, goreleaser-docker]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,7 +123,7 @@ jobs:
         id: check-ecr-images
         run: |
           REPO_NAME="${{ github.event.repository.name }}"
-          TAG="${{ inputs.tag }}"
+          TAG="${{ .Version }}"
 
           # Check if the arm64 image already exists
           if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag="${TAG}-arm64" --region us-west-2 >/dev/null 2>&1; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,8 +127,11 @@ jobs:
           TAG="${{ inputs.tag }}"
           VERSION="${TAG#v}"
           
+          echo "Checking if ECR image ${REPO_NAME}:${VERSION}-arm64 exists"
+          aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids ${VERSION}-arm64 --region us-west-2
+
           # Check if the arm64 image already exists
-          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag="${VERSION}-arm64" --region us-west-2 >/dev/null 2>&1; then
+          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids ${VERSION}-arm64 --region us-west-2 >/dev/null 2>&1; then
             echo "ECR image ${REPO_NAME}:${VERSION}-arm64 already exists"
             echo "images_exist=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,10 +128,10 @@ jobs:
           VERSION="${TAG#v}"
           
           echo "Checking if ECR image ${REPO_NAME}:${VERSION}-arm64 exists"
-          aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag=${VERSION}-arm64 --region us-west-2
+          aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag="${VERSION}-arm64" --region us-west-2
 
           # Check if the arm64 image already exists
-          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag=${VERSION}-arm64 --region us-west-2 >/dev/null 2>&1; then
+          if aws ecr describe-images --repository-name "${REPO_NAME}" --image-ids imageTag="${VERSION}-arm64" --region us-west-2 >/dev/null 2>&1; then
             echo "ECR image ${REPO_NAME}:${VERSION}-arm64 already exists"
             echo "images_exist=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Checks if an ECR image already exists for the tag and skips if true. This allows retrying the workflow when the goreleaser step fails.

TODO:
- The GH Actions for each connector repo need to have the `ecr:DescribeImages` AWS permission.