### PR TITLE
fix lambda invocation retry logic for recording release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,57 +179,23 @@ jobs:
           aws-region: us-west-2
       - name: Invoke Lambda with retries
         run: |
-          set +e  # Disable default fail-fast to support retries
-          set -x  # Debug logging
+          set +e    # Disable default fail-fast to support retries
+          if [[ "$ACTIONS_STEP_DEBUG" == "true" ]]; then
+            set -x  # Debug logging
+          fi
 
           TMPFILE=$(mktemp)
           MAX_RETRIES=5
           RETRY_DELAY=10  # seconds
 
-          fake_lambda_invoke() {
-            local outfile="$1"
-
-            # Randomly select a behavior
-            local options=("success" "fail" "init" "badstatus")
-            local behavior=${options[$RANDOM % ${#options[@]}]}
-
-            echo "Simulating Lambda behavior: $behavior"
-
-            case "$behavior" in
-              success)
-                echo '{"statusCode":200,"body":"OK"}' > "$outfile"
-                return 0
-                ;;
-              init)
-                echo '{"statusCode":500,"body":"Initializing"}' > "$outfile"
-                echo "An error occurred (CodeArtifactUserPendingException) when calling the Invoke operation: Lambda is initializing"
-                return 255
-                ;;
-              fail)
-                echo '{"statusCode":500,"body":"Failure"}' > "$outfile"
-                echo "An error occurred (ResourceNotFoundException) when calling the Invoke operation: Function not found"
-                return 1
-                ;;
-              badstatus)
-                echo '{"statusCode":403,"body":"Forbidden"}' > "$outfile"
-                return 0
-                ;;
-              *)
-                echo "Unknown behavior '$behavior'"
-                return 2
-                ;;
-            esac
-          }
-
           for ((i=1; i<=MAX_RETRIES; i++)); do
             echo "Attempt $i to invoke Lambda..."
 
-            # RESPONSE=$(aws lambda invoke \
-            #   --function-name "${{ github.event.repository.name }}-releases" \
-            #   --payload "{\"repository\":\"${{ github.event.repository.full_name }}\", \"tag\":\"${{ inputs.tag }}\"}" \
-            #   --cli-binary-format raw-in-base64-out \
-            #   "$TMPFILE" 2>&1)
-            RESPONSE=$(fake_lambda_invoke "$TMPFILE")
+            RESPONSE=$(aws lambda invoke \
+              --function-name "${{ github.event.repository.name }}-releases" \
+              --payload "{\"repository\":\"${{ github.event.repository.full_name }}\", \"tag\":\"${{ inputs.tag }}\"}" \
+              --cli-binary-format raw-in-base64-out \
+              "$TMPFILE" 2>&1)
             EXIT_CODE=$?
 
             echo "AWS CLI exited with code: $EXIT_CODE"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,6 +179,9 @@ jobs:
           aws-region: us-west-2
       - name: Invoke Lambda with retries
         run: |
+          set +e  # Disable default fail-fast to support retries
+          set -x  # Debug logging
+
           TMPFILE=$(mktemp)
           MAX_RETRIES=5
           RETRY_DELAY=10  # seconds
@@ -191,30 +194,38 @@ jobs:
               --payload "{\"repository\":\"${{ github.event.repository.full_name }}\", \"tag\":\"${{ inputs.tag }}\"}" \
               --cli-binary-format raw-in-base64-out \
               "$TMPFILE" 2>&1)
+            EXIT_CODE=$?
 
-            # Check if the invoke was successful (exit code 0) and response has 200 status code
-            if [[ $? -eq 0 ]] && [[ "$(cat $TMPFILE)" == *"\"statusCode\":200"* ]]; then
-                cat "$TMPFILE"
-                echo "Lambda invoked successfully."
-                break
+            echo "AWS CLI exited with code: $EXIT_CODE"
+            cat "$TMPFILE"
+
+            STATUS_CODE=$(jq -r '.statusCode' < "$TMPFILE" 2>/dev/null)
+
+            if [[ $EXIT_CODE -eq 0 && "$STATUS_CODE" == "200" ]]; then
+              echo "Lambda invoked successfully."
+              break
+
             elif [[ "$RESPONSE" == *"CodeArtifactUserPendingException"* ]]; then
-                cat "$TMPFILE"
-                # Only retry for this specific transient error
-                if [[ $i -lt MAX_RETRIES ]]; then
-                    WAIT_TIME=$((i * RETRY_DELAY))
-                    echo "Lambda not ready yet. Retrying in $WAIT_TIME seconds..."
-                    sleep $WAIT_TIME
-                else
-                    echo "Failed to invoke Lambda after $MAX_RETRIES attempts."
-                    exit 1
-                fi
-            else
-                cat "$TMPFILE"
-                # Any other error should fail immediately
-                echo "Lambda invoke failed with error: $RESPONSE"
+              echo "Lambda not ready (CodeArtifactUserPendingException)."
+
+              if [[ $i -lt $MAX_RETRIES ]]; then
+                WAIT_TIME=$((i * RETRY_DELAY))
+                echo "Retrying in $WAIT_TIME seconds..."
+                sleep "$WAIT_TIME"
+              else
+                echo "Lambda still not ready after $MAX_RETRIES attempts."
+                rm -f "$TMPFILE"
                 exit 1
+              fi
+
+            else
+              echo "Lambda invoke failed with unexpected error: $RESPONSE"
+              rm -f "$TMPFILE"
+              exit 1
             fi
           done
+
+          rm -f "$TMPFILE"
 
   notify-failure:
     needs: [goreleaser, goreleaser-docker, record-release]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,14 +186,50 @@ jobs:
           MAX_RETRIES=5
           RETRY_DELAY=10  # seconds
 
+          fake_lambda_invoke() {
+            local outfile="$1"
+
+            # Randomly select a behavior
+            local options=("success" "fail" "init" "badstatus")
+            local behavior=${options[$RANDOM % ${#options[@]}]}
+
+            echo "Simulating Lambda behavior: $behavior"
+
+            case "$behavior" in
+              success)
+                echo '{"statusCode":200,"body":"OK"}' > "$outfile"
+                return 0
+                ;;
+              init)
+                echo '{"statusCode":500,"body":"Initializing"}' > "$outfile"
+                echo "An error occurred (CodeArtifactUserPendingException) when calling the Invoke operation: Lambda is initializing"
+                return 255
+                ;;
+              fail)
+                echo '{"statusCode":500,"body":"Failure"}' > "$outfile"
+                echo "An error occurred (ResourceNotFoundException) when calling the Invoke operation: Function not found"
+                return 1
+                ;;
+              badstatus)
+                echo '{"statusCode":403,"body":"Forbidden"}' > "$outfile"
+                return 0
+                ;;
+              *)
+                echo "Unknown behavior '$behavior'"
+                return 2
+                ;;
+            esac
+          }
+
           for ((i=1; i<=MAX_RETRIES; i++)); do
             echo "Attempt $i to invoke Lambda..."
 
-            RESPONSE=$(aws lambda invoke \
-              --function-name "${{ github.event.repository.name }}-releases" \
-              --payload "{\"repository\":\"${{ github.event.repository.full_name }}\", \"tag\":\"${{ inputs.tag }}\"}" \
-              --cli-binary-format raw-in-base64-out \
-              "$TMPFILE" 2>&1)
+            # RESPONSE=$(aws lambda invoke \
+            #   --function-name "${{ github.event.repository.name }}-releases" \
+            #   --payload "{\"repository\":\"${{ github.event.repository.full_name }}\", \"tag\":\"${{ inputs.tag }}\"}" \
+            #   --cli-binary-format raw-in-base64-out \
+            #   "$TMPFILE" 2>&1)
+            RESPONSE=$(fake_lambda_invoke "$TMPFILE")
             EXIT_CODE=$?
 
             echo "AWS CLI exited with code: $EXIT_CODE"


### PR DESCRIPTION
changes the script to `set +e` to disable the default fail-fast, which github actions have automatically set to `-e`. also improves handling for response, status code, and exit code.

tested using a mock lambda function inplace of the aws command:
```
fake_lambda_invoke() {
  local outfile="$1"

  # Randomly select a behavior
  local options=("success" "fail" "init" "badstatus")
  local behavior=${options[$RANDOM % ${#options[@]}]}

  echo "Simulating Lambda behavior: $behavior"

  case "$behavior" in
    success)
      echo '{"statusCode":200,"body":"OK"}' > "$outfile"
      return 0
      ;;
    init)
      echo '{"statusCode":500,"body":"Initializing"}' > "$outfile"
      echo "An error occurred (CodeArtifactUserPendingException) when calling the Invoke operation: Lambda is initializing"
      return 255
      ;;
    fail)
      echo '{"statusCode":500,"body":"Failure"}' > "$outfile"
      echo "An error occurred (ResourceNotFoundException) when calling the Invoke operation: Function not found"
      return 1
      ;;
    badstatus)
      echo '{"statusCode":403,"body":"Forbidden"}' > "$outfile"
      return 0
      ;;
    *)
      echo "Unknown behavior '$behavior'"
      return 2
      ;;
  esac
}
```
<img width="909" height="232" alt="Screenshot 2025-07-23 at 10 31 57" src="https://github.com/user-attachments/assets/23506520-4514-4fdf-9447-8b40d214bada" />

See all the different run attempts for `baton-github-test` for the different test cases and outcomes: https://github.com/ConductorOne/baton-github-test/actions/runs/16473214871
