### PR TITLE
Add action to get baton.

### DIFF
--- a/actions/get-baton/action.yaml
+++ b/actions/get-baton/action.yaml
@@ -1,0 +1,11 @@
+name: Get Baton
+description: Get the latest version of Baton and install it in /usr/local/bin/
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download Baton
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: ${{ github.action_path }}/get-baton.sh
+      shell: bash

--- a/actions/get-baton/get-baton.sh
+++ b/actions/get-baton/get-baton.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+if [ "${ARCH}" = "x86_64" ]; then
+  ARCH="amd64"
+fi
+
+RELEASES_URL="https://api.github.com/repos/conductorone/baton/releases/latest"
+BASE_URL="https://github.com/conductorone/baton/releases/download"
+
+curl_opts=(--fail-with-body "${RELEASES_URL}")
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  curl_opts+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+DOWNLOAD_URL=$(curl "${curl_opts[@]}" | jq --raw-output ".assets[].browser_download_url | match(\"${BASE_URL}/v[.0-9]+/baton-v[.0-9]+-${OS}-${ARCH}.*\"; \"i\").string")
+FILENAME=$(basename ${DOWNLOAD_URL})
+
+curl -LO ${DOWNLOAD_URL}
+tar xzf ${FILENAME}
+
+mv baton /usr/local/bin/baton


### PR DESCRIPTION
This action gets the latest version of baton and puts it in /usr/loca/bin/

Example of a successful run: https://github.com/ConductorOne/baton-http/actions/runs/16476895281/job/46581733175#step:4:60

By using this, we can delete the get-baton.sh script that's in a ton of repos. Also it uses the github token for API requests, so we shouldn't get rate limit errors.