### PR TITLE
improve release failure notifications

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -249,14 +249,12 @@ jobs:
               text: |
                 %%%
                 # Release Failed ${{ github.event.repository.name }}:${{ inputs.tag }}
+                [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
                 ## Details
                 * **Repository:** `${{ github.event.repository.full_name }}`
                 * **Release Tag:** `${{ inputs.tag }}`
                 * **Workflow:** `baton-connector-release`
                 * **Action Run ID:** `${{ github.run_id }}`
-
-                ## Links
-                [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
                 %%%
               alert_type: "error"
               host: ${{ github.repository_owner }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -234,35 +234,6 @@ jobs:
 
           rm -f "$TMPFILE"
 
-  notify-lambda-failure:
-    needs: [goreleaser, goreleaser-docker, record-lambda-release]
-    if: failure() && inputs.lambda == true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send Datadog event on failure
-        uses: masci/datadog@v1
-        with:
-          api-key: ${{ secrets.DATADOG_API_KEY }}
-          api-url: https://us3.datadoghq.com/
-          events: |
-            - title: "Baton Connector Release Failed"
-              text: |
-                %%%
-                # Release Failed ${{ github.event.repository.name }}:${{ inputs.tag }}
-                [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-                ## Details
-                * **Repository:** `${{ github.event.repository.full_name }}`
-                * **Release Tag:** `${{ inputs.tag }}`
-                * **Workflow:** `baton-connector-release`
-                * **Action Run ID:** `${{ github.run_id }}`
-                %%%
-              alert_type: "error"
-              host: ${{ github.repository_owner }}
-              tags:
-                - "github_repository:${{ github.event.repository.full_name }}"
-                - "github_release_tag:${{ inputs.tag }}"
-                - "github_workflow:baton-connector-release"
-
   goreleaser-docker-no-lambda:
     if: inputs.lambda == false
     permissions:
@@ -314,3 +285,38 @@ jobs:
           args: release --clean --config ../_workflows/.goreleaser.docker.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.RELENG_GITHUB_TOKEN }}
+
+  notify-release-failure:
+    needs:
+      [
+        goreleaser,
+        goreleaser-docker,
+        goreleaser-docker-no-lambda,
+        record-lambda-release,
+      ]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Datadog event on failure
+        uses: masci/datadog@v1
+        with:
+          api-key: ${{ secrets.DATADOG_API_KEY }}
+          api-url: https://us3.datadoghq.com/
+          events: |
+            - title: "Baton Connector Release Failed"
+              text: |
+                %%%
+                # Release Failed ${{ github.event.repository.name }}:${{ inputs.tag }}
+                [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+                ## Details
+                * **Repository:** `${{ github.event.repository.full_name }}`
+                * **Release Tag:** `${{ inputs.tag }}`
+                * **Workflow:** `baton-connector-release`
+                * **Action Run ID:** `${{ github.run_id }}`
+                %%%
+              alert_type: "error"
+              host: ${{ github.repository_owner }}
+              tags:
+                - "github_repository:${{ github.event.repository.full_name }}"
+                - "github_release_tag:${{ inputs.tag }}"
+                - "github_workflow:baton-connector-release"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,11 +88,6 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - name: REMOVE AFTER TESTING - Simulate OIDC Role Assumption Error
-        run: |
-          echo "Error: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity"
-          exit 1
-
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -295,8 +295,68 @@ jobs:
         record-lambda-release,
       ]
     if: failure()
+    permissions:
+      checks: read
+      actions: read
+      contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: Collect failure annotations
+        id: collect-ann
+        continue-on-error: true # never block the Datadog notification
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Get the latest attempt number for this workflow run
+          run_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID")"
+          attempt="$(echo "$run_json" | jq -r '.run_attempt')"
+
+          # List jobs for the *specific* attempt (prevents mixing earlier attempts)
+          jobs_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID/attempts/$attempt/jobs?per_page=100" --paginate)"
+
+          # Filter to failed jobs in this attempt
+          failed_jobs=$(echo "$jobs_json" | jq -r '.jobs[] | select(.conclusion=="failure") | @base64')
+
+          out=""
+          if [ -z "$failed_jobs" ]; then
+            out="No failure annotations found for latest attempt (#${attempt})."
+          else
+            while IFS= read -r enc; do
+              j() { echo "$enc" | base64 -d | jq -r "$1"; }
+              name="$(j '.name')"
+              check_run_url="$(j '.check_run_url')"
+
+              # Resolve check run ID for this attempt and fetch its annotations
+              check_id="$(gh api "$check_run_url" -H "Accept: application/vnd.github+json" | jq -r '.id')"
+
+              anns="$(gh api "repos/$REPO/check-runs/$check_id/annotations?per_page=100" \
+                      --paginate -H "Accept: application/vnd.github+json" | \
+                      jq -r '.[] | select(.annotation_level=="failure") | .message' || true)"
+
+              if [ -n "$anns" ]; then
+                while IFS= read -r msg; do
+                  oneline="$(printf "%s" "$msg" | tr '\n' ' ' | sed 's/  \+/ /g')"
+                  out+="$name: $oneline"$'\n'
+                done <<< "$anns"
+              else
+                out+="$name: (no failure-level annotations; step may have failed before annotating)"$'\n'
+              fi
+            done <<< "$failed_jobs"
+          fi
+
+          # Keep Datadog payload compact (~4k limit on text)
+          out="$(printf "%s" "$out" | tail -c 3500)"
+
+          {
+            echo "annotations<<'EOF'"
+            printf "%s\n" "$out"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Send Datadog event on failure
         uses: masci/datadog@v1
         with:
@@ -308,6 +368,10 @@ jobs:
                 %%%
                 # Release Failed ${{ github.event.repository.name }}:${{ inputs.tag }}
                 [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+                ## Error
+                ```${steps.collect-ann.outputs.annotations}```
+
                 ## Details
                 * **Repository:** `${{ github.event.repository.full_name }}`
                 * **Release Tag:** `${{ inputs.tag }}`

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -371,12 +371,10 @@ jobs:
             - title: "Baton Connector Release Failed"
               text: |
                 %%%
-                # ${{ github.event.repository.name }}:${{ inputs.tag }} Release Failed
-                [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
+                # `${{ github.event.repository.name }}`:`${{ inputs.tag }}` Release Failed
                 ## Error
+                [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
                 ```${{ steps.collect-ann.outputs.annotations }}```
-
                 ## Details
                 * **Repository:** `${{ github.event.repository.full_name }}`
                 * **Release Tag:** `${{ inputs.tag }}`

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -357,8 +357,8 @@ jobs:
           out="$(printf "%s" "$out" | tail -c 3500)"
 
           {
-            echo "annotations<<'EOF'"
-            printf "%s\n" "$out"
+            echo "annotations<<EOF"
+            printf '%s\n' "$out"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -371,11 +371,11 @@ jobs:
             - title: "Baton Connector Release Failed"
               text: |
                 %%%
-                # Release Failed ${{ github.event.repository.name }}:${{ inputs.tag }}
+                # ${{ github.event.repository.name }}:${{ inputs.tag }} Release Failed
                 [View Workflow Run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
                 ## Error
-                ```${steps.collect-ann.outputs.annotations}```
+                ```${{ steps.collect-ann.outputs.annotations }}```
 
                 ## Details
                 * **Repository:** `${{ github.event.repository.full_name }}`

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,11 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: REMOVE AFTER TESTING - Simulate OIDC Role Assumption Error
+        run: |
+          echo "Error: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity"
+          exit 1
+
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
This PR makes a number of improvements to the failure notifications:
- moves the `View Workflow Run` link higher up in the payload, above the fold in slack messages
- attempts to capture the error reason(s) from the failed step(s) and add them to the event payload - note this new step never blocks on failure
- updates the notification logic to report release failures for all/any steps `goreleaser`, `goreleaser-docker`, `goreleaser-docker-no-lambda`, `record-lambda-release`

Example from testing:
<img width="1028" height="940" alt="Screenshot 2025-08-19 at 10 06 56" src="https://github.com/user-attachments/assets/60ffcd0a-7edd-47e6-96df-21ac153cd828" />
<img width="802" height="511" alt="Screenshot 2025-08-19 at 10 10 07" src="https://github.com/user-attachments/assets/3311462f-914c-4a41-b5b7-2703aae94897" />

Before to this PR:
<img width="715" height="411" alt="Screenshot 2025-08-19 at 10 18 55" src="https://github.com/user-attachments/assets/58859793-3593-4be7-8253-bf9f0cd371a0" />

