### PR TITLE
[BB-540] add account provisioning test

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,40 @@ The get-baton action downloads the latest version of [Baton](https://github.com/
 
 You can then use the baton command in your workflow.
 
+### Sync Test
+
+The sync-test action tests syncing, granting, and revoking for a baton connector.
+
+#### Usage
+
+```yaml
+- name: Test Connector Sync
+  uses: ConductorOne/github-workflows/actions/sync-test@v2
+  with:
+    connector: './my-connector'
+    baton-entitlement: 'admin-role'
+    baton-principal: 'user123'
+    baton-principal-type: 'user'
+```
+
+### Account Provisioning Test
+
+The account-provisioning action tests account provisioning and deprovisioning for a baton connector that supports these capabilities.
+
+#### Usage
+
+```yaml
+- name: Test Account Provisioning
+  uses: ConductorOne/github-workflows/actions/account-provisioning@v2
+  with:
+    connector: './my-connector'
+    baton-account-login: 'testuser'
+    baton-account-email: 'test@example.com'
+    baton-account-profile: '{"first_name": "Test", "last_name": "User", "username": "testuser", "email": "test@example.com"}'
+    baton-display-name: 'Test User'
+    baton-account-type: 'user'
+```
+
 
 ## Development
 

--- a/actions/account-provisioning/README.md
+++ b/actions/account-provisioning/README.md
@@ -1,0 +1,54 @@
+# Connector Account Provisioning Test Action
+
+This action tests account provisioning and deprovisioning for a baton connector that supports these capabilities.
+
+## Usage
+
+```yaml
+- name: Test Account Provisioning
+  uses: ./.github/actions/account-provisioning
+  with:
+    connector: './my-connector'
+    baton-account-login: 'testuser'
+    baton-account-email: 'test@example.com'
+    baton-account-profile: '{"first_name": "Test", "last_name": "User", "username": "testuser", "email": "test@example.com"}'
+    baton-display-name: 'Test User'
+    baton-account-type: 'user'
+```
+
+## Inputs
+
+### Required
+- `connector`: Connector binary to test
+- `baton-account-login`: Account login to test provisioning
+- `baton-account-email`: Account email to test provisioning
+- `baton-account-profile`: Account profile JSON to test provisioning
+- `baton-display-name`: Display name for the test account
+
+### Optional
+- `baton-account-type`: Type of account to test provisioning (default: 'user')
+
+## What it tests
+
+The action performs a complete account lifecycle test:
+
+1. **Account Creation**: Creates a new account with the specified login, email, and profile
+2. **Verification**: Verifies the account was created successfully by checking for its existence
+3. **Account Deletion**: Deletes the created account
+4. **Delete Again**: Attempts to delete the already-deleted account (tests duplicate deletion handling)
+5. **Cleanup Verification**: Verifies the account was completely removed
+
+## Capability Detection
+
+The action automatically detects if the connector supports the required capabilities:
+- If `CAPABILITY_ACCOUNT_PROVISIONING` is not found, account provisioning tests are skipped
+- If `CAPABILITY_RESOURCE_DELETE` is not found, account deprovisioning tests are skipped
+
+## When to use
+
+Use this action when you want to test that your connector properly supports:
+- Creating new user accounts
+- Deleting existing user accounts
+- Proper cleanup and verification of account operations
+
+This action is separate from the sync-test action since not all connectors support account provisioning capabilities.

--- a/actions/account-provisioning/account-provisioning.sh
+++ b/actions/account-provisioning/account-provisioning.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -exo pipefail
+
+if [ -z "$BATON_CONNECTOR" ]; then
+  echo "BATON_CONNECTOR not set"
+  exit 1
+fi
+if [ -z "$BATON" ]; then
+  echo "BATON not set. using baton"
+  BATON=baton
+fi
+
+if ! command -v $BATON &> /dev/null; then
+  echo "$BATON not found"
+  exit 1
+fi
+
+# Error on unbound variables now that we've set BATON
+set -u
+
+# Sync
+$BATON_CONNECTOR
+
+set +e
+CAPABILITY_ACCOUNT_PROVISIONING=$($BATON_CONNECTOR capabilities | jq --raw-output --exit-status '.connectorCapabilities[] | select(contains("CAPABILITY_ACCOUNT_PROVISIONING") )')
+CAPABILITY_RESOURCE_DELETE=$($BATON_CONNECTOR capabilities | jq --raw-output --exit-status '.connectorCapabilities[] | select(contains("CAPABILITY_RESOURCE_DELETE") )')
+set -e
+
+if [ -z "$CAPABILITY_ACCOUNT_PROVISIONING" ]; then
+  echo "CAPABILITY_ACCOUNT_PROVISIONING not found. Skipping account provisioning tests."
+  exit 0
+fi
+
+if [ -z "$CAPABILITY_RESOURCE_DELETE" ]; then
+  echo "CAPABILITY_RESOURCE_DELETE not found. Skipping account deprovisioning tests."
+  exit 0
+fi
+
+# create -> check -> delete -> delete again -> check
+
+# create account
+$BATON_CONNECTOR --create-account-login="$BATON_ACCOUNT_LOGIN" \
+                 --create-account-email="$BATON_ACCOUNT_EMAIL" \
+                 --create-account-profile="$BATON_ACCOUNT_PROFILE"
+
+# check if account was created
+$BATON_CONNECTOR
+CREATED_ACCOUNT_ID=$($BATON resources -t user --output-format=json \
+  | jq -r \
+       --arg display_name "$BATON_DISPLAY_NAME" \
+       --arg login "$BATON_ACCOUNT_LOGIN" \
+       --arg email "$BATON_ACCOUNT_EMAIL" \
+       '.resources[] |
+          select(
+            .resource.displayName == $display_name or
+            .resource.displayName == $login or
+            .resource.displayName == $email
+          ) |
+          .resource.id.resource')
+
+if [ -n "$CREATED_ACCOUNT_ID" ]; then
+  echo "Account created successfully with ID: $CREATED_ACCOUNT_ID"
+else
+  echo "Failed to create account"
+  exit 1
+fi
+
+# delete account
+$BATON_CONNECTOR --delete-resource "$CREATED_ACCOUNT_ID" --delete-resource-type "$BATON_ACCOUNT_TYPE"
+
+# delete account already deleted
+$BATON_CONNECTOR --delete-resource "$CREATED_ACCOUNT_ID" --delete-resource-type "$BATON_ACCOUNT_TYPE"
+
+# check if account was deleted
+$BATON_CONNECTOR
+$BATON principals --output-format=json \
+  | jq -e \
+       --arg name "$BATON_ACCOUNT_LOGIN" \
+       '.resources | map(select(.resource.annotations[0].profile.username == $name)) | length == 0'

--- a/actions/account-provisioning/action.yaml
+++ b/actions/account-provisioning/action.yaml
@@ -1,0 +1,41 @@
+name: Connector Account Provisioning Test
+description: Test account provisioning and deprovisioning for a baton connector that supports these capabilities.
+
+inputs:
+  connector:
+    description: 'Connector binary to test'
+    required: true
+  baton-account-login:
+    description: 'Account login to test provisioning'
+    required: true
+  baton-account-email:
+    description: 'Account email to test provisioning'
+    required: true
+  baton-account-profile:
+    description: 'Account profile JSON to test provisioning'
+    required: true
+  baton-display-name:
+    description: 'Display name for the test account'
+    required: true
+  baton-account-type:
+    description: 'Type of account to test provisioning. If not provided, will default to "user".'
+    required: false
+    default: 'user'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download Baton
+      uses: ConductorOne/github-workflows/actions/get-baton@v2
+
+    - name: Account Provisioning Test
+      env:
+        BATON_CONNECTOR: ${{ inputs.connector }}
+        BATON_ACCOUNT_LOGIN: ${{ inputs.baton-account-login }}
+        BATON_ACCOUNT_EMAIL: ${{ inputs.baton-account-email }}
+        BATON_ACCOUNT_PROFILE: ${{ inputs.baton-account-profile }}
+        BATON_DISPLAY_NAME: ${{ inputs.baton-display-name }}
+        BATON_ACCOUNT_TYPE: ${{ inputs.baton-account-type }}
+        BATON: baton
+      run: ${{ github.action_path }}/account-provisioning.sh
+      shell: bash


### PR DESCRIPTION
**Add account provisioning and deprovisioning test action for baton connectors**

Creates a new dedicated action to test account lifecycle operations (create → verify → delete → delete again → verify) with proper capability validation for connectors that support account provisioning.